### PR TITLE
ダッシュボードの強化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ TAG=$(shell git rev-parse --short HEAD)
 PORT=80
 
 run:
-	poetry run uvicorn futaba2dat.main:app \
+	mkdir -p ./db
+	DB_NAME=./db/log.sqlite poetry run uvicorn futaba2dat.main:app \
 		--host 0.0.0.0 \
 		--port $(PORT) \
 		--reload \
@@ -22,9 +23,12 @@ run:
 		--forwarded-allow-ips "*"
 
 docker-run: docker-build
+	mkdir -p ./db
 	docker run --rm \
 		--name futaba2dat \
 		--env 'TZ=Asia/Tokyo' \
+		--env 'DB_NAME=/app/db/log.sqlite' \
+		-v "$(PWD)/db:/app/db" \
 		-p $(PORT):80 \
 		futaba2dat:$(TAG)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,6 @@ services:
       TZ: "Asia/Tokyo"
       DB_NAME: "/app/db/log.sqlite"
       LANG: "C.UTF-8"
+    # 現在のユーザーのUID:GIDでコンテナを実行
+    user: "${UID:-1000}:${GID:-1000}"
     restart: unless-stopped

--- a/futaba2dat/db.py
+++ b/futaba2dat/db.py
@@ -53,32 +53,30 @@ def get_recent(engine: sa.engine.Connectable) -> list[History]:
     """すべてのメッセージを取得する"""
     with engine.connect() as connection:
         query = (
-            sa.sql.select(
-                (
-                    history_table.c.id,
-                    history_table.c.title,
-                    history_table.c.link,
-                    history_table.c.board,
-                    history_table.c.host,
-                    history_table.c.created_at,
-                )
+            sa.select(
+                history_table.c.id,
+                history_table.c.title,
+                history_table.c.link,
+                history_table.c.board,
+                history_table.c.host,
+                history_table.c.created_at,
             )
             .order_by(history_table.c.created_at.desc())
             .limit(50)
         )
-        return [History(**m) for m in connection.execute(query)]
+        return [History(**m._asdict()) for m in connection.execute(query)]
 
 
 def add(engine: sa.engine.Connectable, history: History) -> None:
     """メッセージを保存する"""
-    with engine.connect() as connection:
+    with engine.begin() as connection:
         query = history_table.insert()
         connection.execute(query, history.dict(exclude_unset=True))
 
 
 def delete_all(engine: sa.engine.Connectable) -> None:
     """メッセージをすべて消す（テスト用）"""
-    with engine.connect() as connection:
+    with engine.begin() as connection:
         connection.execute(history_table.delete())
 
 

--- a/futaba2dat/db.py
+++ b/futaba2dat/db.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Optional
 
 import sqlalchemy as sa
@@ -79,3 +80,97 @@ def delete_all(engine: sa.engine.Connectable) -> None:
     """メッセージをすべて消す（テスト用）"""
     with engine.connect() as connection:
         connection.execute(history_table.delete())
+
+
+def get_dashboard_analytics(engine: sa.engine.Connectable) -> dict:
+    """ダッシュボード用の分析データを取得する"""
+    with engine.connect() as connection:
+        # 過去1週間の基準日時
+        week_ago = (datetime.datetime.now() - datetime.timedelta(days=7)).isoformat()
+        # 過去1日の基準日時
+        day_ago = (datetime.datetime.now() - datetime.timedelta(days=1)).isoformat()
+
+        # 1. 過去1週間の人気板ランキング（アクセス数順）
+        board_popularity_query = sa.text("""
+            SELECT board, COUNT(*) as access_count
+            FROM histories 
+            WHERE created_at > :week_ago
+            GROUP BY board 
+            ORDER BY access_count DESC 
+            LIMIT 10
+        """)
+        board_popularity = list(
+            connection.execute(board_popularity_query, {"week_ago": week_ago})
+        )
+
+        # 2. 過去1週間の人気スレッドランキング（アクセス数順）
+        thread_popularity_query = sa.text("""
+            SELECT title, link, board, COUNT(*) as access_count
+            FROM histories 
+            WHERE created_at > :week_ago
+            GROUP BY title, link, board 
+            ORDER BY access_count DESC 
+            LIMIT 10
+        """)
+        thread_popularity = list(
+            connection.execute(thread_popularity_query, {"week_ago": week_ago})
+        )
+
+        # 3. 過去1日のユニークユーザー数
+        unique_users_day_query = sa.text("""
+            SELECT COUNT(DISTINCT host) as unique_users
+            FROM histories 
+            WHERE created_at > :day_ago
+        """)
+        unique_users_day = connection.execute(
+            unique_users_day_query, {"day_ago": day_ago}
+        ).scalar()
+
+        # 4. 過去1週間のユニークユーザー数
+        unique_users_week_query = sa.text("""
+            SELECT COUNT(DISTINCT host) as unique_users
+            FROM histories 
+            WHERE created_at > :week_ago
+        """)
+        unique_users_week = connection.execute(
+            unique_users_week_query, {"week_ago": week_ago}
+        ).scalar()
+
+        # 5. 過去1週間の総アクセス数
+        total_access_week_query = sa.text("""
+            SELECT COUNT(*) as total_access
+            FROM histories 
+            WHERE created_at > :week_ago
+        """)
+        total_access_week = connection.execute(
+            total_access_week_query, {"week_ago": week_ago}
+        ).scalar()
+
+        # 6. 過去1日の総アクセス数
+        total_access_day_query = sa.text("""
+            SELECT COUNT(*) as total_access
+            FROM histories 
+            WHERE created_at > :day_ago
+        """)
+        total_access_day = connection.execute(
+            total_access_day_query, {"day_ago": day_ago}
+        ).scalar()
+
+        return {
+            "board_popularity": [
+                {"board": row[0], "access_count": row[1]} for row in board_popularity
+            ],
+            "thread_popularity": [
+                {
+                    "title": row[0],
+                    "link": row[1],
+                    "board": row[2],
+                    "access_count": row[3],
+                }
+                for row in thread_popularity
+            ],
+            "unique_users_day": unique_users_day or 0,
+            "unique_users_week": unique_users_week or 0,
+            "total_access_day": total_access_day or 0,
+            "total_access_week": total_access_week or 0,
+        }

--- a/futaba2dat/main.py
+++ b/futaba2dat/main.py
@@ -128,13 +128,14 @@ async def get(
     return templates.TemplateResponse("index.j2", context)
 
 
-# 閲覧履歴
+# 閲覧履歴とダッシュボード
 @app.get("/log", response_class=HTMLResponse)
 async def log(
     request: Request, engine: sa.engine.Connectable = Depends(get_engine)
 ) -> Response:
     histories = db.get_recent(engine)
-    context = {"request": request, "histories": histories}
+    analytics = db.get_dashboard_analytics(engine)
+    context = {"request": request, "histories": histories, "analytics": analytics}
     return templates.TemplateResponse("log.j2", context)
 
 

--- a/futaba2dat/main.py
+++ b/futaba2dat/main.py
@@ -165,7 +165,7 @@ async def get(
     request: Request, engine: sa.engine.Connectable = Depends(get_engine)
 ) -> Response:
     context = {"request": request}
-    return templates.TemplateResponse("index.j2", context)
+    return templates.TemplateResponse(request, "index.j2", context)
 
 
 # 閲覧履歴とダッシュボード
@@ -176,7 +176,7 @@ async def log(
     histories = db.get_recent(engine)
     analytics = db.get_dashboard_analytics(engine)
     context = {"request": request, "histories": histories, "analytics": analytics}
-    return templates.TemplateResponse("log.j2", context)
+    return templates.TemplateResponse(request, "log.j2", context)
 
 
 # chmateの場合, 板のhtml内に<title>が含まれていればそれを板の名前としている.
@@ -184,6 +184,7 @@ async def log(
 @app.get("/{sub_domain}/{board_dir}/")
 async def board_top(request: Request, sub_domain: str, board_dir: str):
     generated_content = templates.TemplateResponse(
+        request,
         "board.j2",
         {
             "request": request,
@@ -201,6 +202,7 @@ async def board_top(request: Request, sub_domain: str, board_dir: str):
 @app.get("/{sub_domain}/{board_dir}/SETTING.TXT")
 async def setting_txt(request: Request, sub_domain: str, board_dir: str):
     generated_content = templates.TemplateResponse(
+        request,
         "setting.j2",
         {
             "request": request,
@@ -224,7 +226,7 @@ async def subject(request: Request, sub_domain: str, board_dir: str):
         threads = list(filter(lambda x: x["count"] != 0, threads))
 
     generated_content = templates.TemplateResponse(
-        "subject.j2", {"request": request, "threads": threads}
+        request, "subject.j2", {"request": request, "threads": threads}
     )
     generated_content.headers["content-type"] = "text/plain"
     generated_content = convert_to_shiftjis(generated_content)
@@ -282,6 +284,7 @@ async def thread(
 
     image_url_root = Settings().futaba_image_url_root.format(sub_domain, board_dir)
     generated_content = templates.TemplateResponse(
+        request,
         "thread.j2",
         {
             "request": request,
@@ -308,6 +311,7 @@ async def bbsmenu(
         mod_boards = boards
 
     generated_content = templates.TemplateResponse(
+        request,
         "bbsmenu.j2",
         {"request": request, "boards": mod_boards},
     )

--- a/futaba2dat/main.py
+++ b/futaba2dat/main.py
@@ -36,7 +36,47 @@ db_engine = sa.create_engine(
 )
 db.create_table(db_engine)
 
+
+def time_ago(timestamp_str: str) -> str:
+    """タイムスタンプから相対時間を生成（n秒前、n分前など）"""
+    try:
+        # ISO形式のタイムスタンプをパース（naive datetime として扱う）
+        timestamp = datetime.datetime.fromisoformat(timestamp_str.replace("Z", ""))
+        now = datetime.datetime.now()
+        diff = now - timestamp
+
+        seconds = int(diff.total_seconds())
+
+        # 負の値の場合は絶対値を取る（未来の時刻の場合）
+        seconds = abs(seconds)
+
+        if seconds < 60:
+            return f"{seconds}秒前"
+        elif seconds < 3600:
+            minutes = seconds // 60
+            return f"{minutes}分前"
+        elif seconds < 86400:
+            hours = seconds // 3600
+            return f"{hours}時間前"
+        else:
+            days = seconds // 86400
+            return f"{days}日前"
+    except Exception:
+        # パースエラーの場合は元の形式で表示
+        try:
+            return (
+                timestamp_str.split("T")[0]
+                + " "
+                + timestamp_str.split("T")[1].split(".")[0]
+            )
+        except:
+            return timestamp_str
+
+
 templates = Jinja2Templates(directory="templates")
+# カスタムフィルターを追加
+templates.env.filters["time_ago"] = time_ago
+
 boards = json.load(open("./futaba2dat/boards.json", "r"))
 boards_hash = {}
 for i in boards:

--- a/templates/log.j2
+++ b/templates/log.j2
@@ -147,7 +147,7 @@
                     <tr>
                       <td>{{history.board}}</td>
                       <td><a href="{{ history.link }}" class="text-decoration-none"> {{history.title|truncate(60)}} </a></td>
-                      <td><small class="text-muted">{{ history.created_at.split('T')[0] }} {{ history.created_at.split('T')[1].split('.')[0] }}</small></td>
+                      <td><small class="text-muted">{{ history.created_at | time_ago }}</small></td>
                     </tr>
                     {% endfor %}
                   </tbody>

--- a/templates/log.j2
+++ b/templates/log.j2
@@ -2,35 +2,160 @@
 <html lang="ja">
 
 <head>
-  <title>futaba2dat</title>
+  <title>futaba2dat - ダッシュボード</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
     integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
   <link href="{{ url_for('static', path='index.css') }}" rel="stylesheet">
+  <style>
+    .stat-card {
+      background: #f8f9fa;
+      border-left: 4px solid #007bff;
+      padding: 1rem;
+      margin-bottom: 1rem;
+    }
+    .stat-number {
+      font-size: 2rem;
+      font-weight: bold;
+      color: #007bff;
+    }
+    .ranking-item {
+      border-bottom: 1px solid #dee2e6;
+      padding: 0.5rem 0;
+    }
+    .ranking-item:last-child {
+      border-bottom: none;
+    }
+    .rank-number {
+      background: #007bff;
+      color: white;
+      border-radius: 50%;
+      width: 24px;
+      height: 24px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.8rem;
+      font-weight: bold;
+      margin-right: 0.5rem;
+    }
+  </style>
 </head>
 
 <body>
   <div class="container-fluid">
     <div id="main-area" class="my-5 px-sm-5 py-5">
       <div class="px-3">
-        <h4>閲覧履歴</h4>
-        <table class="table">
-          <thead>
-            <tr>
-              <th>板名</th>
-              <th>スレッド</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for history in histories %}
-            <tr>
-              <td>{{history.board}}</td>
-              <td><a href="{{ history.link }}"> {{history.title}} </a></td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+        <h2 class="mb-4">ダッシュボード</h2>
+        
+        <!-- 統計情報カード -->
+        <div class="row mb-4">
+          <div class="col-md-3">
+            <div class="stat-card">
+              <div class="stat-number">{{ analytics.total_access_day }}</div>
+              <div class="text-muted">過去24時間のアクセス数</div>
+            </div>
+          </div>
+          <div class="col-md-3">
+            <div class="stat-card">
+              <div class="stat-number">{{ analytics.total_access_week }}</div>
+              <div class="text-muted">過去1週間のアクセス数</div>
+            </div>
+          </div>
+          <div class="col-md-3">
+            <div class="stat-card">
+              <div class="stat-number">{{ analytics.unique_users_day }}</div>
+              <div class="text-muted">過去24時間のユニークユーザー</div>
+            </div>
+          </div>
+          <div class="col-md-3">
+            <div class="stat-card">
+              <div class="stat-number">{{ analytics.unique_users_week }}</div>
+              <div class="text-muted">過去1週間のユニークユーザー</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ランキング -->
+        <div class="mb-4">
+          <div class="card">
+            <div class="card-header">
+              <h5 class="card-title mb-0">人気板ランキング（過去1週間）</h5>
+            </div>
+            <div class="card-body">
+              {% if analytics.board_popularity %}
+                {% for board in analytics.board_popularity %}
+                <div class="ranking-item">
+                  <span class="rank-number">{{ loop.index }}</span>
+                  <strong>{{ board.board }}</strong>
+                  <span class="badge badge-primary ml-2">{{ board.access_count }}回</span>
+                </div>
+                {% endfor %}
+              {% else %}
+                <p class="text-muted">データがありません</p>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+
+        <div class="mb-4">
+          <div class="card">
+            <div class="card-header">
+              <h5 class="card-title mb-0">人気スレッドランキング（過去1週間）</h5>
+            </div>
+            <div class="card-body">
+              {% if analytics.thread_popularity %}
+                {% for thread in analytics.thread_popularity %}
+                <div class="ranking-item">
+                  <span class="rank-number">{{ loop.index }}</span>
+                  <div>
+                    <a href="{{ thread.link }}" class="text-decoration-none">
+                      {{ thread.title|truncate(50) }}
+                    </a>
+                    <br>
+                    <small class="text-muted">{{ thread.board }}</small>
+                    <span class="badge badge-primary ml-2">{{ thread.access_count }}回</span>
+                  </div>
+                </div>
+                {% endfor %}
+              {% else %}
+                <p class="text-muted">データがありません</p>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+
+        <!-- 最近の閲覧履歴 -->
+        <div class="mt-4">
+          <div class="card">
+            <div class="card-header">
+              <h5 class="card-title mb-0">最近の閲覧履歴</h5>
+            </div>
+            <div class="card-body">
+              <div class="table-responsive">
+                <table class="table table-sm">
+                  <thead>
+                    <tr>
+                      <th>板名</th>
+                      <th>スレッド</th>
+                      <th>アクセス時刻</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for history in histories %}
+                    <tr>
+                      <td>{{history.board}}</td>
+                      <td><a href="{{ history.link }}" class="text-decoration-none"> {{history.title|truncate(60)}} </a></td>
+                      <td><small class="text-muted">{{ history.created_at.split('T')[0] }} {{ history.created_at.split('T')[1].split('.')[0] }}</small></td>
+                    </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/tests/test_db_index.py
+++ b/tests/test_db_index.py
@@ -65,8 +65,8 @@ def test_query_uses_index():
             },
         ]
 
-        for data in test_data:
-            conn.execute(history_table.insert(), data)
+        stmt = history_table.insert()
+        conn.execute(stmt, test_data)
 
         # 実行計画確認
         query = "EXPLAIN QUERY PLAN SELECT * FROM histories ORDER BY created_at DESC LIMIT 50"


### PR DESCRIPTION

# 概要

  /logエンドポイントをシンプルな履歴表示から、統計情報とランキングを含むリッチなダッシュボードに強化。

# 主な変更

## 🚀 新機能

  - ダッシュボード分析機能:
    - 過去24時間/1週間のアクセス数・ユニークユーザー数
    - 人気板・人気スレッドランキング（過去1週間、TOP10）
  - 相対時間表示: 「30秒前」「5分前」「2時間前」形式
  - レスポンシブUI: Bootstrap活用したカード式レイアウト

## 🔧 技術改善

  - Docker最適化:
    - Poetry 2.0対応
    - 非rootユーザー実行（UID/GID 1000:1000）
    - マルチステージビルド強化
    - ヘルスチェック追加
  - 開発環境統一: make runとmake docker-runで同じ./dbディレクトリ使用
  - 警告修正:
    - Starlette TemplateResponse API更新（7箇所）
    - SQLAlchemy select()構文現代化

## 📁 変更ファイル

  - futaba2dat/main.py: time_agoフィルター追加、TemplateResponse修正
  - futaba2dat/db.py: get_dashboard_analytics()関数追加、SQLAlchemy構文更新
  - templates/log.j2: ダッシュボードUI実装
  - Dockerfile: セキュリティ・パフォーマンス改善
  - docker-compose.yml: user権限設定
  - Makefile: 開発環境統一

## 🧪 品質向上

  - 全テスト通過継続
  - make test警告数: 9個→1個に削減
  - SQLインジェクション対策（パラメータ化クエリ）

## パフォーマンス考慮

  - created_atインデックス活用で高速絞り込み
  - LIMIT 10でランキングクエリ効率化
  - 複数統計を1関数で一括取得
