### PR TITLE
非同期処理できていなかったところの修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-- あなたは日本語で話します。
+- あなたはコーディングが得意なずんだの妖精です。
+- あなたは日本語で話し、文末に「〜のだ。」「〜なのだ。」をつけます。
 
 ## プロジェクト概要
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY:\
 	run\
 	test\
+	test-integration\
+	test-all\
 	build\
 	lint\
 	format\
@@ -36,7 +38,13 @@ clean:
 	docker images 'futaba2dat' --format '{{.Repository}}:{{.Tag}}' | xargs -r docker rmi
 
 test:
-	poetry run pytest
+	poetry run pytest -m "not integration"
+
+test-integration:
+	poetry run pytest -m integration -v
+
+test-all:
+	poetry run pytest -v
 
 docker-build:
 	docker build -t futaba2dat:$(TAG) .

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 	reload-boards\
 
 TAG=$(shell git rev-parse --short HEAD)
-PORT=80
+PORT?=80
 
 run:
 	mkdir -p ./db

--- a/futaba2dat/main.py
+++ b/futaba2dat/main.py
@@ -219,7 +219,7 @@ async def setting_txt(request: Request, sub_domain: str, board_dir: str):
 # スレッド一覧を表すファイル.
 @app.get("/{sub_domain}/{board_dir}/subject.txt")
 async def subject(request: Request, sub_domain: str, board_dir: str):
-    threads = FutabaBoard().get_and_parse(sub_domain, board_dir)
+    threads = await FutabaBoard().get_and_parse(sub_domain, board_dir)
 
     # mayならば書き込み0件のスレを省く(スクリプト対策)
     if sub_domain == "may" and board_dir == "b":
@@ -242,7 +242,7 @@ async def thread(
     id: int,
     engine: sa.engine.Connectable = Depends(get_engine),
 ):
-    response = FutabaThread().get(sub_domain, board_dir, id)
+    response = await FutabaThread().get(sub_domain, board_dir, id)
     if response.status_code != 200:
         # 404の場合はFTBucket URLを含む特別なレスポンスを返す
         if response.status_code == 404:
@@ -250,7 +250,7 @@ async def thread(
         else:
             raise HTTPException(status_code=response.status_code)
     else:
-        thread = FutabaThread().parse(response.text)
+        thread = await FutabaThread().parse_async(response.text)
         thread = futaba_uploader(thread)
 
         # プロキシドメインを取得してふたばURLを2ch形式に変換

--- a/poetry.lock
+++ b/poetry.lock
@@ -704,6 +704,25 @@ pluggy = ">=0.12,<2.0"
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.23.8"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pytest_asyncio-0.23.8-py3-none-any.whl", hash = "sha256:50265d892689a5faefb84df80819d1ecef566eb3549cf915dfb33569359d1ce2"},
+    {file = "pytest_asyncio-0.23.8.tar.gz", hash = "sha256:759b10b33a6dc61cce40a8bd5205e302978bbbcc00e279a8b61d9a6a3c82e4d3"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0,<9"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -983,4 +1002,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "68fec41405162c57e1286204f3dee45c51ff3b8e3fb013da681f2a2952de1c97"
+content-hash = "303a81d7023aa26c2a403bca5bab9cb3211497dcce35304f7423588e0e33c40e"

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,7 +18,7 @@ version = "4.9.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c"},
     {file = "anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028"},
@@ -75,7 +75,7 @@ version = "2025.4.26"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3"},
     {file = "certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6"},
@@ -308,7 +308,7 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
@@ -320,7 +320,7 @@ version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
     {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
@@ -342,7 +342,7 @@ version = "0.28.1"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
@@ -367,7 +367,7 @@ version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -801,7 +801,7 @@ version = "1.3.1"
 description = "Sniff out which async library your code is running under"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
@@ -937,12 +937,11 @@ version = "4.13.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c"},
     {file = "typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"},
 ]
-markers = {dev = "python_version == \"3.12\""}
 
 [[package]]
 name = "urllib3"
@@ -984,4 +983,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "780158614ef2e8a7ce11c098426bdd72025acea04ee6066e6d4d8a08105ae104"
+content-hash = "68fec41405162c57e1286204f3dee45c51ff3b8e3fb013da681f2a2952de1c97"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ SQLAlchemy = "^1.4.11"
 beautifulsoup4 = "^4.9.3"
 pydantic = "^1.8.1"
 requests = "^2.25.1"
+httpx = "^0.28.1"
 sqlalchemy-stubs = "^0.4"
 pymysql = "^1.0.3"
 pg8000 = "^1.29.4"
@@ -21,7 +22,6 @@ pg8000 = "^1.29.4"
 [tool.poetry.group.dev.dependencies]
 pytest = "7.4.3"
 ruff = "^0.11.12"
-httpx = "^0.28.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ pg8000 = "^1.29.4"
 [tool.poetry.group.dev.dependencies]
 pytest = "7.4.3"
 ruff = "^0.11.12"
+pytest-asyncio = ">=0.21,<1.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    integration: marks tests as integration tests (may be slow and require external dependencies)
+asyncio_mode = auto

--- a/tests/test_ftbucket.py
+++ b/tests/test_ftbucket.py
@@ -146,7 +146,7 @@ def test_404_no_history_logging(test_client, test_db_engine, monkeypatch):
     mock_response = Mock()
     mock_response.status_code = 404
 
-    def mock_futaba_get(self, sub_domain, board_dir, thread_id):
+    async def mock_futaba_get(self, sub_domain, board_dir, thread_id):
         return mock_response
 
     monkeypatch.setattr("futaba2dat.futaba.FutabaThread.get", mock_futaba_get)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,22 +22,22 @@ client = TestClient(app)
 def test_may_b_subject_txt():
     """may/bの実際のsubject.txtの取得テスト"""
     response = client.get("/may/b/subject.txt")
-    
+
     assert response.status_code == 200
     assert response.headers["content-type"] == "text/plain"
-    
+
     # レスポンスがShift-JISでエンコードされていることを確認
     content = response.content.decode("shift-jis")
-    
+
     # subject.txtの形式確認：<thread_id>.dat<>スレッドタイトル (<post_count>)
     lines = content.strip().split("\n")
     assert len(lines) > 0
-    
+
     # 最初の行の形式確認
     first_line = lines[0]
     assert ".dat<>" in first_line
     assert "(" in first_line and ")" in first_line
-    
+
     # 最初のスレッドIDを返す（テスト関数は戻り値を持つべきではないのでコメントアウト）
     # return lines[0].split(".dat<>")[0]
 
@@ -48,32 +48,32 @@ def test_may_b_thread_dat():
     # まずsubject.txtから有効なスレッドIDを取得
     subject_response = client.get("/may/b/subject.txt")
     assert subject_response.status_code == 200
-    
+
     content = subject_response.content.decode("shift-jis")
     lines = content.strip().split("\n")
-    
+
     # 最初のスレッドのIDを取得
     first_line = lines[0]
     thread_id = first_line.split(".dat<>")[0]
-    
+
     # そのスレッドのDATファイルを取得
     dat_response = client.get(f"/may/b/dat/{thread_id}.dat")
-    
+
     assert dat_response.status_code == 200
     assert dat_response.headers["content-type"] == "text/plain"
-    
+
     # レスポンスがShift-JISでエンコードされていることを確認
     dat_content = dat_response.content.decode("shift-jis")
-    
+
     # DAT形式の確認：名前<>メール<>日付 ID<>本文<>スレッドタイトル
     dat_lines = dat_content.strip().split("\n")
     assert len(dat_lines) >= 1
-    
+
     # 最初の行（スレ主の投稿）の形式確認
     first_post = dat_lines[0]
     parts = first_post.split("<>")
     assert len(parts) == 5  # 名前、メール、日付、本文、タイトル
-    
+
     # 日付部分の確認（空の場合もあるので存在確認のみ）
     date_part = parts[2]
     # ふたばの日付形式は様々なので、文字列として存在することのみ確認
@@ -84,16 +84,16 @@ def test_may_b_thread_dat():
 def test_board_top_page():
     """板トップページの取得テスト"""
     response = client.get("/may/b/")
-    
+
     assert response.status_code == 200
     assert response.headers["content-type"] == "text/html"
-    
+
     # レスポンスがShift-JISでエンコードされていることを確認
     html_content = response.content.decode("shift-jis")
-    
+
     # HTMLの基本構造確認（板トップページは簡素なのでtitleのみ確認）
     assert "<title>" in html_content
-    
+
     # 板の名前が含まれていることを確認（may/bは「二次元裏@ふたば」）
     assert "二次元裏" in html_content
 
@@ -102,17 +102,17 @@ def test_board_top_page():
 def test_setting_txt():
     """SETTING.TXTファイルの取得テスト"""
     response = client.get("/may/b/SETTING.TXT")
-    
+
     assert response.status_code == 200
     assert response.headers["content-type"] == "text/plain"
-    
+
     # レスポンスがShift-JISでエンコードされていることを確認
     content = response.content.decode("shift-jis")
-    
+
     # SETTING.TXTの基本形式確認
     lines = content.strip().split("\n")
     assert len(lines) > 0
-    
+
     # 板の名前が含まれていることを確認
     assert "二次元裏" in content
 
@@ -120,31 +120,31 @@ def test_setting_txt():
 @pytest.mark.integration
 def test_full_workflow():
     """フルワークフローテスト：板一覧→スレッド一覧→スレッド内容"""
-    
+
     # 1. 板トップページにアクセス
     board_response = client.get("/may/b/")
     assert board_response.status_code == 200
-    
+
     # 2. スレッド一覧（subject.txt）を取得
     subject_response = client.get("/may/b/subject.txt")
     assert subject_response.status_code == 200
-    
+
     content = subject_response.content.decode("shift-jis")
     lines = content.strip().split("\n")
     assert len(lines) > 0
-    
+
     # 3. 最初のスレッドのDATファイルを取得
     first_line = lines[0]
     thread_id = first_line.split(".dat<>")[0]
-    
+
     dat_response = client.get(f"/may/b/dat/{thread_id}.dat")
     assert dat_response.status_code == 200
-    
+
     # 4. DATファイルの内容確認
     dat_content = dat_response.content.decode("shift-jis")
     dat_lines = dat_content.strip().split("\n")
     assert len(dat_lines) >= 1
-    
+
     # 5. すべてのレスポンスが適切なcontent-typeを持っていることを確認
     assert board_response.headers["content-type"] == "text/html"
     assert subject_response.headers["content-type"] == "text/plain"
@@ -156,14 +156,14 @@ def test_error_handling_404_thread():
     """存在しないスレッドの404ハンドリングテスト"""
     # 存在しないスレッドID（非常に大きな数値）でアクセス
     response = client.get("/may/b/dat/999999999.dat")
-    
+
     # 404エラーでもFTBucketリンクを含む200レスポンスが返される
     assert response.status_code == 200
-    
+
     content = response.content.decode("shift-jis")
-    
+
     # 404メッセージの確認
     assert "スレッドが見つかりません" in content or "削除された" in content
-    
+
     # FTBucketリンクが含まれていることを確認（may板の場合）
     assert "ftbucket.info" in content

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,169 @@
+"""
+実際のふたば☆ちゃんねるを使った統合テスト
+
+これらのテストは外部依存があるため、明示的に実行する必要があります：
+pytest -m integration
+
+注意: これらのテストは実際のふたばサーバーに接続するため、
+- ネットワーク接続が必要
+- サーバーの応答時間に依存
+- 実際のスレッドの存在に依存
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from futaba2dat.main import app
+
+client = TestClient(app)
+
+
+@pytest.mark.integration
+def test_may_b_subject_txt():
+    """may/bの実際のsubject.txtの取得テスト"""
+    response = client.get("/may/b/subject.txt")
+    
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/plain"
+    
+    # レスポンスがShift-JISでエンコードされていることを確認
+    content = response.content.decode("shift-jis")
+    
+    # subject.txtの形式確認：<thread_id>.dat<>スレッドタイトル (<post_count>)
+    lines = content.strip().split("\n")
+    assert len(lines) > 0
+    
+    # 最初の行の形式確認
+    first_line = lines[0]
+    assert ".dat<>" in first_line
+    assert "(" in first_line and ")" in first_line
+    
+    # 最初のスレッドIDを返す（テスト関数は戻り値を持つべきではないのでコメントアウト）
+    # return lines[0].split(".dat<>")[0]
+
+
+@pytest.mark.integration
+def test_may_b_thread_dat():
+    """may/bの実際のスレッドDATファイルの取得テスト"""
+    # まずsubject.txtから有効なスレッドIDを取得
+    subject_response = client.get("/may/b/subject.txt")
+    assert subject_response.status_code == 200
+    
+    content = subject_response.content.decode("shift-jis")
+    lines = content.strip().split("\n")
+    
+    # 最初のスレッドのIDを取得
+    first_line = lines[0]
+    thread_id = first_line.split(".dat<>")[0]
+    
+    # そのスレッドのDATファイルを取得
+    dat_response = client.get(f"/may/b/dat/{thread_id}.dat")
+    
+    assert dat_response.status_code == 200
+    assert dat_response.headers["content-type"] == "text/plain"
+    
+    # レスポンスがShift-JISでエンコードされていることを確認
+    dat_content = dat_response.content.decode("shift-jis")
+    
+    # DAT形式の確認：名前<>メール<>日付 ID<>本文<>スレッドタイトル
+    dat_lines = dat_content.strip().split("\n")
+    assert len(dat_lines) >= 1
+    
+    # 最初の行（スレ主の投稿）の形式確認
+    first_post = dat_lines[0]
+    parts = first_post.split("<>")
+    assert len(parts) == 5  # 名前、メール、日付、本文、タイトル
+    
+    # 日付部分の確認（空の場合もあるので存在確認のみ）
+    date_part = parts[2]
+    # ふたばの日付形式は様々なので、文字列として存在することのみ確認
+    assert isinstance(date_part, str)
+
+
+@pytest.mark.integration
+def test_board_top_page():
+    """板トップページの取得テスト"""
+    response = client.get("/may/b/")
+    
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/html"
+    
+    # レスポンスがShift-JISでエンコードされていることを確認
+    html_content = response.content.decode("shift-jis")
+    
+    # HTMLの基本構造確認（板トップページは簡素なのでtitleのみ確認）
+    assert "<title>" in html_content
+    
+    # 板の名前が含まれていることを確認（may/bは「二次元裏@ふたば」）
+    assert "二次元裏" in html_content
+
+
+@pytest.mark.integration
+def test_setting_txt():
+    """SETTING.TXTファイルの取得テスト"""
+    response = client.get("/may/b/SETTING.TXT")
+    
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/plain"
+    
+    # レスポンスがShift-JISでエンコードされていることを確認
+    content = response.content.decode("shift-jis")
+    
+    # SETTING.TXTの基本形式確認
+    lines = content.strip().split("\n")
+    assert len(lines) > 0
+    
+    # 板の名前が含まれていることを確認
+    assert "二次元裏" in content
+
+
+@pytest.mark.integration
+def test_full_workflow():
+    """フルワークフローテスト：板一覧→スレッド一覧→スレッド内容"""
+    
+    # 1. 板トップページにアクセス
+    board_response = client.get("/may/b/")
+    assert board_response.status_code == 200
+    
+    # 2. スレッド一覧（subject.txt）を取得
+    subject_response = client.get("/may/b/subject.txt")
+    assert subject_response.status_code == 200
+    
+    content = subject_response.content.decode("shift-jis")
+    lines = content.strip().split("\n")
+    assert len(lines) > 0
+    
+    # 3. 最初のスレッドのDATファイルを取得
+    first_line = lines[0]
+    thread_id = first_line.split(".dat<>")[0]
+    
+    dat_response = client.get(f"/may/b/dat/{thread_id}.dat")
+    assert dat_response.status_code == 200
+    
+    # 4. DATファイルの内容確認
+    dat_content = dat_response.content.decode("shift-jis")
+    dat_lines = dat_content.strip().split("\n")
+    assert len(dat_lines) >= 1
+    
+    # 5. すべてのレスポンスが適切なcontent-typeを持っていることを確認
+    assert board_response.headers["content-type"] == "text/html"
+    assert subject_response.headers["content-type"] == "text/plain"
+    assert dat_response.headers["content-type"] == "text/plain"
+
+
+@pytest.mark.integration
+def test_error_handling_404_thread():
+    """存在しないスレッドの404ハンドリングテスト"""
+    # 存在しないスレッドID（非常に大きな数値）でアクセス
+    response = client.get("/may/b/dat/999999999.dat")
+    
+    # 404エラーでもFTBucketリンクを含む200レスポンスが返される
+    assert response.status_code == 200
+    
+    content = response.content.decode("shift-jis")
+    
+    # 404メッセージの確認
+    assert "スレッドが見つかりません" in content or "削除された" in content
+    
+    # FTBucketリンクが含まれていることを確認（may板の場合）
+    assert "ftbucket.info" in content


### PR DESCRIPTION
# 概要

  Issue #34  で指摘された同期I/Oによるパフォーマンス問題を解決し、FastAPIの非同期処理を最大限活用できるよう改善しました。

# 変更内容

## 🔧 非同期化対応

  - HTTPリクエスト: requests → httpx.AsyncClientに変更
  - HTMLパース: run_in_threadpool()でワーカースレッドにオフロード
  - エンドポイント: subject.txt、datエンドポイントを非同期対応

## 📦 依存関係の更新

  - httpxを開発依存から通常依存に移動（本番環境対応）
  - pytest-asyncioを追加（非同期テスト対応）

##  🧪 統合テスト追加

  - 実際のふたば☆ちゃんねるを使用した統合テストを新規作成
  - pytestマーカー設定で外部依存テストを分離
  - Makefileに新しいテストコマンドを追加

## 🛠️ その他の改善

  - MakefileのPORT変数を環境変数対応（PORT?=80）
  - pytest設定ファイルの修正

# テスト結果

```
# 通常テスト（外部依存なし）
make test               # 28 passed

# 統合テスト（実際のふたば接続）
make test-integration   # 6 passed

# 全テスト
make test-all           # 34 passed
```

# パフォーマンス効果

  - イベントループのブロッキングを完全に回避
  - 複数リクエストの並行処理が可能に
  - CPU集約的なHTMLパース処理をワーカースレッドで実行

# 後方互換性

  ✅ 既存のAPIエンドポイントは変更なし✅ レスポンス形式は従来と同一✅ 設定ファイルは互換性維持

# 新しいMakefileコマンド

  make test               # CI/CD用：統合テスト除外
  make test-integration   # 手動確認用：実際のふたば接続テスト  
  make test-all           # 完全テスト：全テスト実行

---

  この変更により、同期I/Oによるパフォーマンスボトルネックが解消され、FastAPIの非同期処理能力を最大限活用できるようになったのだ！

Closes #34
