### PR TITLE
`allowed_tools` をカンマ区切りにする

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,9 +34,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: "60"
-          allowed_tools: >-
-            Bash(poetry install)
-            Bash(make format)
-            Bash(make lint)
-            Bash(make test)
-            Bash(make build)
+          allowed_tools: "Bash(poetry install),Bash(make format),Bash(make lint),Bash(make test),Bash(make build)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: "60"
-          allowed_tools: |
+          allowed_tools: >-
             Bash(poetry install)
             Bash(make format)
             Bash(make lint)


### PR DESCRIPTION
Claude Code Actionの例には改行で `allowed_tools` を指定している:

https://github.com/anthropics/claude-code-action/blob/3c748dc92755ad477a2b50e53016af5cd29d1776/README.md?plain=1#L381-L394

しかしこの指定方法は認識できず、DeepWikiによるとカンマ区切りしか受け付けないとのこと。

https://deepwiki.com/search/allowedtools_87ac30fe-4de0-43d0-b8b8-c73e4029fa1b

これを修正した。