### PR TITLE
feat: pytest 8.xへのアップグレード

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -692,6 +692,21 @@ toml = ["tomli (>=2.0.1)"]
 yaml = ["pyyaml (>=6.0.1)"]
 
 [[package]]
+name = "pygments"
+version = "2.19.1"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"},
+    {file = "pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pymysql"
 version = "1.1.1"
 description = "Pure Python MySQL Driver"
@@ -709,24 +724,25 @@ rsa = ["cryptography"]
 
 [[package]]
 name = "pytest"
-version = "7.4.3"
+version = "8.4.0"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pytest-7.4.3-py3-none-any.whl", hash = "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac"},
-    {file = "pytest-7.4.3.tar.gz", hash = "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"},
+    {file = "pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e"},
+    {file = "pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6"},
 ]
 
 [package.dependencies]
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-iniconfig = "*"
-packaging = "*"
-pluggy = ">=0.12,<2.0"
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+iniconfig = ">=1"
+packaging = ">=20"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
@@ -1059,4 +1075,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "3f2c5d2ab374426450f322eb2070690aae9a3b2662205f023c791ad249ddc0a3"
+content-hash = "0f5fb7c1d5c469f6f6027e33074c84ee3306ecb99b65fbb9978a719cac950365"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ pymysql = "^1.0.3"
 pg8000 = "^1.29.4"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "7.4.3"
+pytest = "8.4.0"
 ruff = "^0.11.12"
 pytest-asyncio = ">=0.21,<1.0"
 


### PR DESCRIPTION
## 概要

pytest 7.4.3 → 8.4.0 へのメジャーバージョンアップグレードの実施

## 変更内容

- `pyproject.toml`でpytestバージョンを8.4.0に更新
- `poetry.lock`ファイルを更新
- pytest-asyncio互換性確認済み
- 既存のpytest設定は互換性あり

## テスト結果

- ✅ 全31テストが成功
- ✅ コードフォーマット・リントチェック通過

Closes #40

Generated with [Claude Code](https://claude.ai/code)