### PR TITLE
fix: 連続引用符の後にスペースを追加してChMate誤認を修正

### DIFF
--- a/futaba2dat/futaba.py
+++ b/futaba2dat/futaba.py
@@ -194,4 +194,15 @@ class FutabaThread:
         if image_filename:
             thread_res_dict[image_filename] = i
 
+        # ChMateで引用文の数字がレス番号として誤認されることを防ぐため、
+        # 連続する引用符(>)の後にスペースを挿入する処理を追加
+        body_lines = post["body"].split("<br>")
+        processed_lines = []
+        for line in body_lines:
+            # 行頭の連続する>の後に続く文字列にスペースを挿入
+            # >>, >>>, >>>>... の後に数字や文字が続く場合を対象とする
+            processed_line = re.sub(r"^(>+)([^>\s].*)", r"\1 \2", line)
+            processed_lines.append(processed_line)
+        post["body"] = "<br>".join(processed_lines)
+
         return post

--- a/tests/test_futaba.py
+++ b/tests/test_futaba.py
@@ -90,7 +90,7 @@ def test_futaba_thread1() -> None:
                 "id": "ID:xxxxxxxx",
                 "no": "No.000000002",
                 "sod": "+",
-                "body": ">引用<br>本文",
+                "body": "> 引用<br>本文",
                 "quote_res": [2],
             },
             {
@@ -114,7 +114,7 @@ def test_futaba_thread1() -> None:
                 "id": "ID:xxxxxxxx",
                 "no": "No.000000004",
                 "sod": "+",
-                "body": ">0000000000003.jpg<br>画像引用",
+                "body": "> 0000000000003.jpg<br>画像引用",
                 "quote_res": [4],
             },
         ],


### PR DESCRIPTION
ChMateで連続引用符+数字がレス番号として誤認される問題を修正

## 変更内容
- futaba.py: _parse_post関数に正規表現ベースの引用符処理を追加
- tests/test_futaba.py: 期待値をスペース追加後の形式に更新

## 解決する問題
`>>>1富士2鷹3なすび`、`>>1富士2鷹3なすび`、`>1富士2鷹3なすび`をそれぞれ`>>> 1富士2鷹3なすび`、`>> 1富士2鷹3なすび`、`> 1富士2鷹3なすび`に変換し、ChMateでの誤認を防ぐのだ

Closes #49

Generated with [Claude Code](https://claude.ai/code)